### PR TITLE
Export macros to Node requires()

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,6 @@
     "sweet.js": "~0.4.0",
     "chai": "~1.8.0",
     "grunt-mocha-test": "~0.7.0"
-  }
+  },
+  "main": "macros/index.js"
 }


### PR DESCRIPTION
The way it is now, I have no clue how you are supposed to use the package in other projects. With this change, you can refer to the package by name in the macros property.
