### PR TITLE
Allow match to be used as a Statement

### DIFF
--- a/macros/index.js
+++ b/macros/index.js
@@ -1408,7 +1408,7 @@ let function = macro {
 let match = macro {
   case { $ctx $op:expr { $body ... } } => {
     return #{
-      $sparkler__compile $ctx anonymous { $body ... }.call(this, $op)
+      ($sparkler__compile $ctx anonymous { $body ... }.call(this, $op))
     }
   }
   case { _ } => {

--- a/test/patterns.sjs
+++ b/test/patterns.sjs
@@ -365,6 +365,19 @@ describe 'Case patterns' {
 
     test 'success' { foo.go(1) === 42 }
   }
+  
+  it 'should support the match as a statement' {
+    function go(test) {
+      match test {
+        x @ Number => x.toString(),
+        * => null
+      };
+      
+      return true;
+    }
+
+    test 'success' { go(42) === true }
+  }
 
   // Regressions
   // -----------


### PR DESCRIPTION
The `match` operator macro in most pattern-matching languages can be used as a statement. Currently, Sparkler returns an anonymous function expression, which is not a valid statement but can be used as one if simply wrapped in parentheses.

This lets us have syntax like so:

``` rust
var num = 1;
match num {
  0 => alert("zero"),
  1 => alert("one"),
  _ => alert("something else")
}
```

Which will become more useful since I'm working on adding more [Rust-like features](http://static.rust-lang.org/doc/master/tutorial.html#pattern-matching) like multiple patterns via pipe `0 | 1` and ranges `0..10`.
